### PR TITLE
revert using docker.pkg.github.com

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,6 +29,9 @@ jobs:
 
   # Push image to GitHub Package Registry.
   # See also https://docs.docker.com/docker-hub/builds/
+  #
+  # NOTICE: pulling images from GitHub Package Registry requires authentication, even for PUBLIC images!
+  # https://github.community/t5/GitHub-Actions/docker-pull-from-public-GitHub-Package-Registry-fail-with-quot/td-p/32782
   push:
     # Ensure test job passes before pushing image.
     needs: test

--- a/README.md
+++ b/README.md
@@ -32,10 +32,9 @@ Non-GKE clusters should work as well, but not tested.
 Install IPP Admission Webhook:
 
 ```bash
-./ipp.yaml.sh docker.pkg.github.com/akihirosuda/instance-per-pod/ipp:latest | kubectl apply -f -
+docker build -t $IMAGE . && docker push $IMAGE
+./ipp.yaml.sh $IMAGE | kubectl apply -f -
 ```
-
-To install non-`latest` version, you need to specify the image tag accordingly.
 
 You can review the YAML before running `kubectl apply`.
 Note that the YAML contains `Secret` resources.

--- a/ipp.yaml.sh
+++ b/ipp.yaml.sh
@@ -5,14 +5,15 @@ set -o nounset
 set -o pipefail
 set -o errtrace
 
-IMAGE=docker.pkg.github.com/akihirosuda/instance-per-pod/ipp:latest
-if [ "$#" -ne 0 ]; then
-    IMAGE="$1"
+if [ "$#" -ne 1 ]; then
+	echo "Usage: $0 IMAGE"
+	exit 1
 fi
 if ! command -v mkcert >/dev/null; then
 	echo "Missing mkcert (https://github.com/FiloSottile/mkcert)"
 	exit 1
 fi
+IMAGE="$1"
 NAMESPACE="ipp-system"
 SERVICE="ipp"
 SAN="${SERVICE}.${NAMESPACE}.svc"


### PR DESCRIPTION
pulling images from GitHub Package Registry requires authentication, even for PUBLIC images!

https://github.community/t5/GitHub-Actions/docker-pull-from-public-GitHub-Package-Registry-fail-with-quot/td-p/32782

Signed-off-by: Akihiro Suda <akihiro.suda.cz@hco.ntt.co.jp>